### PR TITLE
Compress new user images

### DIFF
--- a/PostConfirmation/lambda_function.py
+++ b/PostConfirmation/lambda_function.py
@@ -1,6 +1,11 @@
 import logging
 import boto3
+import requests
+import io
 from botocore.exceptions import ClientError
+from requests import RequestException
+from PIL import Image
+from io import BytesIO
 
 from user import User
 from base import Session
@@ -9,6 +14,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 cognito_client = boto3.client('cognito-idp')
+s3_client = boto3.client('s3')
 ses_client = boto3.client('ses')
 
 ADMIN_EMAIL = "aspire@maxgala.com"
@@ -54,6 +60,59 @@ def sync_with_db(username, user_type, industry, industry_tags, first_name, last_
     session.commit()
     session.close()
 
+def compress_image_obj(image_obj, quality, bucket_name, object_name):
+    output_path = io.BytesIO()
+    image_obj.save(output_path, image_obj.format)
+    original_file_size = output_path.tell()
+
+    output_path = io.BytesIO()
+    if image_obj.mode in ("RGBA", "P"): image_obj = image_obj.convert("RGB")
+    image_obj.save(output_path, 'JPEG', quality=quality)
+    new_file_size = output_path.tell()
+
+    if new_file_size < original_file_size:
+        output_path.seek(0)
+        s3_client.upload_fileobj(output_path, bucket_name, object_name, ExtraArgs = {"ContentType": 'image/jpeg', 'ACL': 'public-read'})
+        return True
+    else:
+        return False
+
+class UnaccessibleUrlException(Exception):
+    pass
+
+def compress_user_image(user_email, user_pictureURL, userPoolId, quality=25):
+    try:
+        #Get user picture url
+        response = requests.get(user_pictureURL)
+        if not response.ok:
+            raise UnaccessibleUrlException
+    except (UnaccessibleUrlException, RequestException):
+        print("Broken Url")
+    else:
+        if (user_pictureURL.find("blank_profile.png")) < 0:
+            try:
+                image_obj = Image.open(BytesIO(response.content))
+                filename_index = user_pictureURL.find('pictures/')
+                extension_index = user_pictureURL.rfind('.')
+                filename = user_pictureURL[filename_index + 9: extension_index] + '-CompressedTest2.jpg'
+                S3_object_name = user_email + '/pictures/' + filename
+                bucket_name = 'aspire-user-profile'
+                image_compressed = compress_image_obj(image_obj, quality, bucket_name, S3_object_name)
+
+                #Edit cognito reference for picture URL
+                if image_compressed == True:
+                        new_image_url = 'https://aspire-user-profile.s3.amazonaws.com/' + user_email + '/pictures/' + filename
+                        response = cognito_client.admin_update_user_attributes(
+                            UserPoolId=userPoolId,
+                            Username=user_email,
+                            UserAttributes=[
+                                {'Name': 'picture', 'Value': new_image_url} 
+                            ]
+                        )
+            except Exception as exc:
+                print("Exception")
+    return True
+
 
 def handler(event, context):
     logger.info(event)
@@ -65,6 +124,7 @@ def handler(event, context):
     user_email = event['request']['userAttributes']['email']
     user_fname = event['request']['userAttributes']['given_name']
     user_lname = event['request']['userAttributes']['family_name']
+    user_pictureURL = event['request']['userAttributes']['picture']
     user_industry = event['request']['userAttributes'].get(
         'custom:industry', '')
     user_industry_tags = event['request']['userAttributes'].get(
@@ -83,6 +143,11 @@ def handler(event, context):
     elif user_type == 'FREE':
         sync_with_db(user_email, user_type, user_industry, user_industry_tags,
                      user_fname, user_lname, 'ENABLED')
+        #Compress user image
+        userPoolId=event['userPoolId']
+        compress_user_image(user_email, user_pictureURL, userPoolId)
+
+        #Send email
         BODY_TEXT = (f"Salaam {user_fname}!\r\n"
                      "\r\n\n"
                      "Congratulations for successfully signing up on MAX Aspire! We are thrilled to have you on board and can’t wait to make a positive difference in your professional career."
@@ -108,6 +173,11 @@ def handler(event, context):
     elif user_type == 'PAID':
         sync_with_db(user_email, user_type, user_industry, user_industry_tags,
                      user_fname, user_lname, 'ENABLED')
+        #Compress user image
+        userPoolId=event['userPoolId']
+        compress_user_image(user_email, user_pictureURL, userPoolId)
+
+        #Send email
         BODY_TEXT = (f"Salaam {user_fname}!\r\n"
                      "\r\n\n"
                      "Congratulations for successfully signing up on MAX Aspire! We are thrilled to have you on board and can’t wait to make a positive difference in your professional career."
@@ -140,6 +210,11 @@ def handler(event, context):
 
         sync_with_db(user_email, user_type, user_industry, user_industry_tags,
                      user_fname, user_lname, 'DISABLED')
+        #Compress user image
+        userPoolId=event['userPoolId']
+        compress_user_image(user_email, user_pictureURL, userPoolId)
+
+        #Send email
         BODY_TEXT = (f"Salaam {user_fname}!\r\n"
                      "\r\n\n"
                      "Thank you for signing up as a Senior Executive on MAX Aspire. "


### PR DESCRIPTION
Upon confirmation, the profile picture uploaded by new users is compressed (and if applicable, converted) to JPEG at 75% image quality.